### PR TITLE
refactor: use built-in web components

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,6 +1,21 @@
 const { getConfig, setConfig, onClick, onChange, getStatus } = window.DemoMode
 const { plugin: pluginPath, data: dataPath } = LiteLoader.plugins.DemoMode.path
 
+/**
+ * 切换开关状态
+ * @param {HTMLInputElement} el 
+ */
+const toggleSwitch = (el) => {
+  if (el.hasAttribute("is-active")) el.removeAttribute("is-active")
+  else el.setAttribute("is-active", "")
+}
+
+/**
+ * 判断开关状态
+ * @param {HTMLInputElement} el 
+ */
+const isSwitchChecked = (el) => el.hasAttribute("is-active")
+
 const DEMO_MODE_BTN_HTML = `<div id="demoModeBtn" style="app-region: no-drag; display: flex; justify-content: center; margin-bottom: 16px">
   <i style="color: var(--icon_primary); width: 24px">
     <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
@@ -118,43 +133,22 @@ export const onSettingWindowCreated = async (view) => {
   view.insertAdjacentHTML('afterbegin', htmlText)
   // 插入设置页样式
   document.head.insertAdjacentHTML('beforeend', `<link rel="stylesheet" href="${cssFilePath}" />`)
-  // 获取是否为深色模式
-  const prefersColorScheme = window.matchMedia('(prefers-color-scheme: dark)')
-  // 设置深色模式样式
-  const setDarkStyle = () => {
-    document.documentElement.style.setProperty('--fieldset-border-color', 'rgba(255, 255, 255, 0.2)')
-    document.documentElement.style.setProperty('--blur-item-border-bottom-color', 'rgba(255, 255, 255, 0.06)')
-  }
-  // 如果为深色模式，则设置深色模式样式
-  if (prefersColorScheme.matches) {
-    setDarkStyle()
-  }
-  // 监听外观模式变化
-  prefersColorScheme.addEventListener('change', (event) => {
-    if (event.matches) {
-      setDarkStyle()
-    } else {
-      // 移除深色模式样式
-      document.documentElement.style.removeProperty('--fieldset-border-color')
-      document.documentElement.style.removeProperty('--blur-item-border-bottom-color')
-    }
-  })
   // 获取配置
   getConfig(dataPath).then((config) => {
     // 获取设置页所有复选框
-    const checkboxes = view.querySelectorAll('input[type="checkbox"]')
+    const checkboxes = view.querySelectorAll('setting-switch')
     // 遍历复选框
     checkboxes.forEach((checkbox) => {
       // 从配置中获取复选框状态
-      const { checked } = config.checkbox[checkbox.parentNode.parentNode.id][checkbox.name]
+      const { checked } = config.checkbox[checkbox.parentNode.parentNode.id][checkbox.dataset.name]
       // 设置复选框状态
-      if (checked) {
-        checkbox.checked = true
-      }
+      if (checked) toggleSwitch(checkbox)
       // 监听复选框点击
       checkbox.addEventListener('click', () => {
+        // 切换状态
+        toggleSwitch(checkbox)
         // 修改配置
-        config.checkbox[checkbox.parentNode.parentNode.id][checkbox.name].checked = checkbox.checked
+        config.checkbox[checkbox.parentNode.parentNode.id][checkbox.dataset.name].checked = isSwitchChecked(checkbox)
         setConfig(dataPath, config)
       })
     })

--- a/src/setting/setting.css
+++ b/src/setting/setting.css
@@ -1,69 +1,40 @@
-:root {
-  --fieldset-border-color: rgba(0, 0, 0, 0.2);
-  --blur-item-border-bottom-color: rgba(0, 0, 0, 0.04);
+setting-text {
+  margin-right: 10px;
 }
 
-.demo-mode-setting fieldset {
-  margin: 0 2px;
-  padding: 0.35em 0.75em 0.625em;
-  border: 1px solid var(--fieldset-border-color);
-  border-radius: 8px;
+#blurRadiusRange {
+  width: 100%;
 }
 
-.demo-mode-setting legend {
-  padding: 0 2px;
+[type="range"] {
+  -webkit-appearance: none;
+  appearance: none;
+  margin: 0;
+  outline: 0;
+  background-color: transparent;
+  width: 500px;
 }
 
-.demo-mode-setting input {
-  appearance: auto;
+[type="range"]::-webkit-slider-runnable-track {
+  height: 4px;
+  background: #eee;
 }
 
-.demo-mode-setting .setting-item-title {
-  color: var(--text_primary);
-  font-weight: var(--font-bold);
-  font-size: min(var(--font_size_3), 18px);
-  line-height: min(var(--line_height_3), 24px);
-  margin: 0 0 8px 16px;
+[type="range" i]::-webkit-slider-container {
+  height: 20px;
+  overflow: hidden;
 }
 
-.demo-mode-setting .setting-item-content {
-  background-color: var(--fill_light_primary);
-  border-radius: 8px;
-  padding: 0 16px;
-  margin-bottom: 24px;
-}
-
-.demo-mode-setting .setting-item-content .blur-item {
-  display: flex;
-  justify-content: space-between;
-  border-bottom: 1px solid var(--blur-item-border-bottom-color);
-  padding: 12px 0;
-}
-
-.demo-mode-setting .setting-item-content .blur-item .title {
-  display: flex;
-  align-items: center;
-}
-
-.demo-mode-setting .setting-item-content .blur-item .checkbox {
-  display: flex;
-  justify-content: space-between;
-}
-
-.demo-mode-setting .setting-item-content .blur-item .checkbox div {
-  display: flex;
-  align-items: center;
-}
-
-.demo-mode-setting .setting-item-content .blur-radius {
-  display: flex;
-  justify-content: space-between;
-  padding: 12px 0;
-}
-
-.demo-mode-setting .setting-item-content .blur-radius .input {
-  display: flex;
-  justify-items: center;
+[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background-color: var(--text-brand);
+  border: 1px solid transparent;
+  margin-top: -8px;
+  border-image: linear-gradient(var(--text-brand), var(--text-brand)) 0 fill / 8 20 8 0 / 0px 0px 0 2000px;
 }
 
 #blurRadiusNumber {

--- a/src/setting/setting.css
+++ b/src/setting/setting.css
@@ -3,7 +3,7 @@ setting-text {
 }
 
 #blurRadiusRange {
-  width: 100%;
+  width: 88%;
 }
 
 [type="range"] {
@@ -12,7 +12,6 @@ setting-text {
   margin: 0;
   outline: 0;
   background-color: transparent;
-  width: 500px;
 }
 
 [type="range"]::-webkit-slider-runnable-track {

--- a/src/setting/setting.html
+++ b/src/setting/setting.html
@@ -1,110 +1,107 @@
-<div class="demo-mode-setting">
-  <div class="setting-item-title">常规</div>
-  <div class="setting-item-content">
-    <div class="blur-item">
-      <div class="title">模糊项</div>
-      <div class="checkbox">
-        <fieldset id="user">
-          <legend>个人</legend>
-          <div>
-            <input type="checkbox" id="userAvatar" name="avatar" />
-            <label for="userAvatar">头像</label>
-          </div>
-        </fieldset>
-        <fieldset id="sessionList">
-          <legend>会话列表</legend>
-          <div>
-            <input type="checkbox" id="sessionListAvatar" name="avatar" />
-            <label for="sessionListAvatar">头像</label>
-          </div>
-          <div>
-            <input type="checkbox" id="sessionListTitle" name="title" />
-            <label for="sessionListTitle">名称</label>
-          </div>
-          <div>
-            <input type="checkbox" id="sessionListSummary" name="summary" />
-            <label for="sessionListSummary">摘要</label>
-          </div>
-          <div>
-            <input type="checkbox" id="sessionListTime" name="time" />
-            <label for="sessionListTime">时间</label>
-          </div>
-          <div>
-            <input type="checkbox" id="sessionListBubble" name="bubble" />
-            <label for="sessionListBubble">气泡</label>
-          </div>
-        </fieldset>
-        <fieldset id="messageList">
-          <legend>消息列表</legend>
-          <div>
-            <input type="checkbox" id="messageListContactName" name="contactName" />
-            <label for="messageListContactName">顶部名称</label>
-          </div>
-          <div>
-            <input type="checkbox" id="messageListMembersCount" name="membersCount" />
-            <label for="messageListMembersCount">人数（仅群聊）</label>
-          </div>
-          <div>
-            <input type="checkbox" id="messageListAvatar" name="avatar" />
-            <label for="messageListAvatar">头像</label>
-          </div>
-          <div>
-            <input type="checkbox" id="messageListName" name="name" />
-            <label for="messageListName">名称（仅群聊）</label>
-          </div>
-          <div>
-            <input type="checkbox" id="messageListInput" name="input" />
-            <label for="messageListInput">输入框</label>
-          </div>
-          <div>
-            <input type="checkbox" id="messageListTime" name="time" />
-            <label for="messageListTime">时间</label>
-          </div>
-          <div>
-            <input type="checkbox" id="messageListTip" name="tip" />
-            <label for="messageListTip">提示（如撤回）</label>
-          </div>
-          <div>
-            <input type="checkbox" id="messageListLable" name="label" />
-            <label for="messageListLable">头衔</label>
-          </div>
-          <div>
-            <input type="checkbox" id="messageListContent" name="content" />
-            <label for="messageListContent">内容</label>
-          </div>
-        </fieldset>
-        <fieldset id="groupSidebar">
-          <legend>群组侧栏</legend>
-          <div>
-            <input type="checkbox" id="groupSidebarNotice" name="notice" />
-            <label for="groupSidebarNotice">公告</label>
-          </div>
-          <div>
-            <input type="checkbox" id="groupSidebarMembersCount" name="membersCount" />
-            <label for="groupSidebarMembersCount">人数</label>
-          </div>
-          <div>
-            <input type="checkbox" id="groupSidebarAvatar" name="avatar" />
-            <label for="groupSidebarAvatar">头像</label>
-          </div>
-          <div>
-            <input type="checkbox" id="groupSidebarName" name="name" />
-            <label for="groupSidebarName">名称</label>
-          </div>
-          <div>
-            <input type="checkbox" id="groupSidebarLable" name="label" />
-            <label for="groupSidebarLable">头衔</label>
-          </div>
-        </fieldset>
-      </div>
-    </div>
-
-    <div class="blur-radius">
-      <div class="title">模糊度</div>
-      <div class="input">
-        <input type="range" id="blurRadiusRange" name="blur-radius" min="1" max="50" />
-        <input type="number" id="blurRadiusNumber" name="blur-radius" min="1" max="50" />
-      </div>
-    </div>
-  </div>
+<div>
+  <setting-section data-title="模糊项">
+    <setting-panel><setting-list data-direction="row">
+        <setting-list id="user" data-direction="column">
+          <setting-item><setting-text>个人</setting-text></setting-item>
+          <setting-item>
+            <setting-text>头像</setting-text>
+            <setting-switch id="userAvatar" data-name="avatar"></setting-switch>
+          </setting-item>
+        </setting-list>
+        <setting-list id="sessionList" data-direction="column">
+          <setting-item><setting-text>会话列表</setting-text></setting-item>
+          <setting-item>
+            <setting-text>名称</setting-text>
+            <setting-switch id="sessionListAvatar" data-name="avatar"></setting-switch>
+          </setting-item>
+          <setting-item>
+            <setting-text>摘要</setting-text>
+            <setting-switch id="sessionListTitle" data-name="title"></setting-switch>
+          </setting-item>
+          <setting-item>
+            <setting-text>时间</setting-text>
+            <setting-switch id="sessionListSummary" data-name="time"></setting-switch>
+          </setting-item>
+          <setting-item>
+            <setting-text>气泡</setting-text>
+            <setting-switch id="sessionListTime" data-name="bubble"></setting-switch>
+          </setting-item>
+        </setting-list>
+        <setting-list id="messageList" data-direction="column">
+          <setting-item><setting-text>消息列表</setting-text></setting-item>
+          <setting-item>
+            <setting-text>顶部名称</setting-text>
+            <setting-switch id="messageListContactName" data-name="contactName"></setting-switch>
+          </setting-item>
+          <setting-item>
+            <setting-text>人数</setting-text>
+            <setting-text data-type="secondary">（仅群聊）</setting-text>
+            <setting-switch id="messageListMembersCount" data-name="membersCount"></setting-switch>
+          </setting-item>
+          <setting-item>
+            <setting-text>头像</setting-text>
+            <setting-switch id="messageListAvatar" data-name="avatar"></setting-switch>
+          </setting-item>
+          <setting-item>
+            <setting-text>名称</setting-text>
+            <setting-text data-type="secondary">（仅群聊）</setting-text>
+            <setting-switch id="messageListName" data-name="name"></setting-switch>
+          </setting-item>
+          <setting-item>
+            <setting-text>输入框</setting-text>
+            <setting-switch id="messageListInput" data-name="input"></setting-switch>
+          </setting-item>
+          <setting-item>
+            <setting-text>时间</setting-text>
+            <setting-switch id="messageListTime" data-name="time"></setting-switch>
+          </setting-item>
+          <setting-item>
+            <setting-text>提示</setting-text>
+            <setting-text data-type="secondary">（如撤回）</setting-text>
+            <setting-switch id="messageListTip" data-name="tip"></setting-switch>
+          </setting-item>
+          <setting-item>
+            <setting-text>头衔</setting-text>
+            <setting-switch id="messageListLable" data-name="label"></setting-switch>
+          </setting-item>
+          <setting-item>
+            <setting-text>内容</setting-text>
+            <setting-switch id="messageListContent" data-name="content"></setting-switch>
+          </setting-item>
+        </setting-list>
+        <setting-list id="groupSidebar" data-direction="column">
+          <setting-item><setting-text>群组侧栏</setting-text></setting-item>
+          <setting-item>
+            <setting-text>公告</setting-text>
+            <setting-switch id="groupSidebarNotice" data-name="notice"></setting-switch>
+          </setting-item>
+          <setting-item>
+            <setting-text>人数</setting-text>
+            <setting-switch id="groupSidebarMembersCount" data-name="membersCount"></setting-switch>
+          </setting-item>
+          <setting-item>
+            <setting-text>头像</setting-text>
+            <setting-switch id="groupSidebarAvatar" data-name="avatar"></setting-switch>
+          </setting-item>
+          <setting-item>
+            <setting-text>名称</setting-text>
+            <setting-switch id="groupSidebarName" data-name="name"></setting-switch>
+          </setting-item>
+          <setting-item>
+            <setting-text>头衔</setting-text>
+            <setting-switch id="groupSidebarLable" data-name="label"></setting-switch>
+          </setting-item>
+        </setting-list>
+      </setting-list></setting-panel>
+  </setting-section>
+  <setting-section data-title="模糊度">
+    <setting-panel>
+      <setting-list data-direction="column">
+        <setting-item>
+          <input type="range" id="blurRadiusRange" data-name="blur-radius" min="1" max="50" />
+          <input type="number" id="blurRadiusNumber" data-name="blur-radius" min="1" max="50" />
+        </setting-item>
+      </setting-list>
+    </setting-panel>
+  </setting-section>
 </div>


### PR DESCRIPTION
## 修改

1. 使用 LiteLoaderQQNT 内置的 Web Components 重构了设置界面，修改了对应的渲染逻辑。
2. 由于其本身支持深浅样式切换，所以移除了原本自动切换深色模式的逻辑。
3. 给 `<input type="range">` 添加了滑动条样式。

## 预览

<img width="560" alt="image" src="https://github.com/qianxuu/LiteLoaderQQNT-Plugin-Demo-Mode/assets/36927158/4e31357e-7947-42ee-8744-c221234f930d">