### PR TITLE
chore: 一些小修改

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -109,16 +109,13 @@ setTimeout(() => {
 
 /**
  * 切换开关状态
- * @param {HTMLInputElement} el
+ * @param {HTMLElement} el
  */
-const toggleSwitch = (el) => {
-  if (el.hasAttribute('is-active')) el.removeAttribute('is-active')
-  else el.setAttribute('is-active', '')
-}
+const toggleSwitch = (el) => el.toggleAttribute('is-active')
 
 /**
  * 判断开关状态
- * @param {HTMLInputElement} el
+ * @param {HTMLElement} el
  */
 const isSwitchChecked = (el) => el.hasAttribute('is-active')
 

--- a/src/setting/setting.css
+++ b/src/setting/setting.css
@@ -1,4 +1,8 @@
-setting-text {
+#blurItems {
+  padding: 16px;
+}
+
+#blurItems setting-text {
   margin-right: 10px;
 }
 

--- a/src/setting/setting.html
+++ b/src/setting/setting.html
@@ -1,6 +1,6 @@
 <setting-section data-title="模糊项">
   <setting-panel>
-    <setting-list data-direction="row">
+    <setting-list id="blurItems" data-direction="row">
       <setting-list id="user" data-direction="column">
         <setting-item>
           <setting-text>个人</setting-text>


### PR DESCRIPTION
1. 添加一个顶层的元素选择器 `blurItems` 防止污染其他页面。
2. 给顶层的 `<setting-list>` 添加左右内边距。
    * 目前 LiteLoader 会给 `data-direction="row"` 的  `<setting-list>` 添加 `padding-top` 和 `padding-bottom`。嵌套的时候作为顶层左右侧会紧贴边缘，有些奇怪。
    * BEFORE: ![image](https://github.com/qianxuu/LiteLoaderQQNT-Plugin-Demo-Mode/assets/36927158/75b0175d-a46d-42bd-b75f-cb4efcc59221)
    * AFTER: ![image](https://github.com/qianxuu/LiteLoaderQQNT-Plugin-Demo-Mode/assets/36927158/6b7f709c-3151-49df-8525-a466d13fa7b6)

2. 简化 `toggleSwitch` 直接使用 `Element.toggleAttribute` 。修改了一下注释。