### PR TITLE
适配新版QQ

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,9 +1,9 @@
 const { getConfig, setConfig, onClick, onChange, getStatus } = window.DemoMode
 const { plugin: pluginPath, data: dataPath } = LiteLoader.plugins.DemoMode.path
 
-const DEMO_MODE_BTN_HTML = `<div id="demoModeBtn" style="app-region: no-drag; display: flex; justify-content: center; margin-bottom: 16px">
+const DEMO_MODE_BTN_HTML = `<div id="demoModeBtn" style="app-region: no-drag; display: flex; justify-content: center; margin-bottom: 6px">
   <i style="color: var(--icon_primary)">
-    <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 -960 960 960" width="24">
+    <svg xmlns="http://www.w3.org/2000/svg" height="18" viewBox="0 -960 960 960" width="18">
       <path
         d="m630.196-422.109-51.892-51.652q24.805-64.543-23.532-106.282-48.337-41.739-102.446-19.696l-50.217-50.457q16.521-10.282 36.804-15.043Q459.196-670 480-670q71 0 120.5 49.5T650-500q0 20.565-5.141 41.706-5.142 21.142-14.663 36.185Zm133.543 134.022-43.587-43.826q47.805-35.761 83.348-79.663 35.543-43.902 53.261-88.424-50.478-110.761-150.12-175.38Q607-740 490-740q-42 0-85.043 7.761-43.044 7.761-66.609 18.282L287.565-765.5q35-16 90.218-28Q433-805.5 485-805.5q143.957 0 264.011 82.337Q869.065-640.826 925.5-500q-25.761 64.478-67.119 118.076-41.359 53.598-94.642 93.837Zm50.109 226.24L649.196-223.74q-35 14-79.239 21.62Q525.717-194.5 480-194.5q-147.196 0-267.75-82.456Q91.696-359.413 34.5-500q19.522-51.761 55.38-101.859 35.859-50.098 86.381-95.815L50.978-822.478l43.913-45.152 759.87 759.869-40.913 45.913Zm-592.522-590.24q-36.761 27.478-70.185 70.402T102.478-500q51.239 111 153.381 175.5Q358-260 488-260q31.565 0 62.728-3.761t47.163-11.761l-64-64q-10.282 4.761-25.445 7.142Q493.283-330 480-330q-70 0-120-49t-50-121q0-14.043 2.261-28.326 2.261-14.283 6.782-25.565l-97.717-98.196ZM530.63-513.435Zm-121.021 60.631Z"
         fill="currentColor"
@@ -41,7 +41,7 @@ const addDemoModeStyle = async () => {
 // 添加演示模式按钮
 const addDemoModeBtn = () => {
   // 获取功能菜单
-  const funcMenu = document.querySelector('.func-menu')
+  const funcMenu = document.querySelector('.func-menu.sidebar__menu')
   if (funcMenu) {
     clearInterval(addDemoModeBtnInterval)
 
@@ -183,3 +183,4 @@ export const onSettingWindowCreated = async (view) => {
     setConfig(dataPath, config)
   })
 }
+


### PR DESCRIPTION
新版QQ上，插件入口没显示在侧边栏了，这样修改一下就显示了
<img width="394" height="704" alt="image" src="https://github.com/user-attachments/assets/a48acc11-5bd8-4b29-ab30-6980486452fe" />
